### PR TITLE
Add OpenBSD support.

### DIFF
--- a/fm/src/actiontriggers.cpp
+++ b/fm/src/actiontriggers.cpp
@@ -6,7 +6,7 @@
 #include <QDockWidget>
 #include <QStatusBar>
 #include <QToolBar>
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/mount.h>
 #else
 #include <sys/vfs.h>

--- a/libfm/common.cpp
+++ b/libfm/common.cpp
@@ -21,7 +21,7 @@
 #include <QPalette>
 #include <QVector>
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/mount.h>
 #else
 #include <sys/vfs.h>

--- a/libfm/fileutils.cpp
+++ b/libfm/fileutils.cpp
@@ -1,7 +1,7 @@
 #include "fileutils.h"
 #include <QDirIterator>
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/mount.h>
 #else
 #include <sys/vfs.h>

--- a/libfm/propertiesdlg.cpp
+++ b/libfm/propertiesdlg.cpp
@@ -29,7 +29,7 @@
 #include "propertiesdlg.h"
 #include "icondlg.h"
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/mount.h>
 #else
 #include <sys/vfs.h>


### PR DESCRIPTION
As it says, this pull request allows qtfm to compile on OpenBSD, and it works perfectly well.
I will shortly be adding qtfm to OpenBSD's package repository.

Thanks!