### PR TITLE
Improve the selection of dfmqtreeview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(
     libfm/propertiesdlg.cpp
     libfm/sortmodel.cpp
     libfm/dfmqtreeview.cpp
+    libfm/dfmqstyleditemdelegate.cpp
     libfm/qtcopydialog/qtcopydialog.cpp
     libfm/qtcopydialog/qtfilecopier.cpp
     libfm/qtcopydialog/qtcopydialog.ui

--- a/libfm/dfmqstyleditemdelegate.cpp
+++ b/libfm/dfmqstyleditemdelegate.cpp
@@ -1,0 +1,39 @@
+#include "dfmqstyleditemdelegate.h"
+
+#include <QAbstractItemModel>
+#include <QAbstractProxyModel>
+#include <QFontMetrics>
+
+DfmQStyledItemDelegate::DfmQStyledItemDelegate(QObject* parent) :
+    QStyledItemDelegate(parent),
+    m_hasMinimizedNameColumnSelection(false)
+{
+}
+
+DfmQStyledItemDelegate::~DfmQStyledItemDelegate()
+{
+}
+
+void DfmQStyledItemDelegate::paint(QPainter* painter,
+                                    const QStyleOptionViewItem& option,
+                                    const QModelIndex& index) const
+{
+    if (m_hasMinimizedNameColumnSelection && (index.column() == COLUMN_NAME)) {
+        QStyleOptionViewItem opt(option);
+
+        QString filename = index.data(Qt::DisplayRole).toString();
+        if (index.isValid()) {
+            const int width = nameColumnWidth(filename, opt);
+            opt.rect.setWidth(width);
+        }
+        QStyledItemDelegate::paint(painter, opt, index);
+    } else {
+        QStyledItemDelegate::paint(painter, option, index);
+    }
+}
+
+int DfmQStyledItemDelegate::nameColumnWidth(const QString& name, const QStyleOptionViewItem& option)
+{
+    QFontMetrics fontMetrics(option.font);
+    return option.decorationSize.width() + fontMetrics.width(name) + 16;
+}

--- a/libfm/dfmqstyleditemdelegate.h
+++ b/libfm/dfmqstyleditemdelegate.h
@@ -1,0 +1,49 @@
+#ifndef DFMQFILEITEMDELEGATE_H
+#define DFMQFILEITEMDELEGATE_H
+
+#include <QtWidgets>
+
+// First column, index 0, is the Name column
+#define COLUMN_NAME 0
+
+/**
+ * Extends QFileItemDelegate by a minimized selection way
+ * for the name column of the details view.
+ */
+class DfmQStyledItemDelegate : public QStyledItemDelegate
+{
+public:
+    explicit DfmQStyledItemDelegate(QObject* parent = 0);
+    virtual ~DfmQStyledItemDelegate();
+
+    /**
+     * If minimized is true, the selection are
+     * only drawn above the icon and text of an item.
+     */
+    void setMinimizedNameColumnSelection(bool minimized);
+    bool hasMinimizedNameColumnSelection() const;
+
+    virtual void paint(QPainter* painter,
+                       const QStyleOptionViewItem& option,
+                       const QModelIndex& index) const;
+
+    /**
+     * Returns the minimized width of the name column for the name.
+     */
+    static int nameColumnWidth(const QString& name, const QStyleOptionViewItem& option);
+
+private:
+    bool m_hasMinimizedNameColumnSelection;
+};
+
+inline void DfmQStyledItemDelegate::setMinimizedNameColumnSelection(bool minimized)
+{
+    m_hasMinimizedNameColumnSelection = minimized;
+}
+
+inline bool DfmQStyledItemDelegate::hasMinimizedNameColumnSelection() const
+{
+    return m_hasMinimizedNameColumnSelection;
+}
+
+#endif // DFMQFILEITEMDELEGATE_H

--- a/libfm/dfmqtreeview.cpp
+++ b/libfm/dfmqtreeview.cpp
@@ -295,7 +295,7 @@ void DfmQTreeView::updateElasticBandSelection()
    QModelIndex toggleIndexRangeBegin = QModelIndex();
 
    do {
-       QRect currIndexRect = visualRect(currIndex);
+       QRect currIndexRect = nameColumnRect(currIndex);
 
         // Update some optimization info as we go.
        const int cr = currIndexRect.right();

--- a/libfm/dfmqtreeview.h
+++ b/libfm/dfmqtreeview.h
@@ -3,6 +3,9 @@
 
 #include <QTreeView>
 
+// First column, index 0, is the Name column
+#define COLUMN_NAME 0
+
 /**
  * Extends QTreeView by a custom selection
  */
@@ -10,7 +13,7 @@ class DfmQTreeView : public QTreeView
 {
     Q_OBJECT
 public:
-    explicit DfmQTreeView(QWidget *parent);
+    explicit DfmQTreeView(QWidget *parent = 0);
     virtual ~DfmQTreeView();
 
     virtual QModelIndex indexAt (const QPoint& point) const;
@@ -57,6 +60,8 @@ private:
     bool m_ignoreScrollTo;    // true if calls to scrollTo(...) should do nothing.
 
     QRect m_dropRect;
+
+    QRect nameColumnRect(const QModelIndex& index) const;
 
     struct ElasticBand
     {

--- a/libfm/dfmqtreeview.h
+++ b/libfm/dfmqtreeview.h
@@ -6,6 +6,8 @@
 // First column, index 0, is the Name column
 #define COLUMN_NAME 0
 
+class DfmQStyledItemDelegate;
+
 /**
  * Extends QTreeView by a custom selection
  */
@@ -60,6 +62,7 @@ private:
     bool m_ignoreScrollTo;    // true if calls to scrollTo(...) should do nothing.
 
     QRect m_dropRect;
+    DfmQStyledItemDelegate* m_fileItemDelegate;
 
     QRect nameColumnRect(const QModelIndex& index) const;
 

--- a/libfm/libfm.pro
+++ b/libfm/libfm.pro
@@ -25,7 +25,8 @@ SOURCES += \
     iconlist.cpp \
     fm.cpp \
     bookmarkmodel.cpp \
-    dfmqtreeview.cpp
+    dfmqtreeview.cpp \
+    dfmqstyleditemdelegate.cpp
 
 HEADERS += \
     applicationdialog.h \
@@ -46,7 +47,8 @@ HEADERS += \
     sortmodel.h \
     fm.h \
     bookmarkmodel.h \
-    dfmqtreeview.h
+    dfmqtreeview.h \
+    dfmqstyleditemdelegate.h
 
 # qtcopydialog
 INCLUDEPATH += qtcopydialog


### PR DESCRIPTION
Improve the selection of dfmqtreeview for https://github.com/rodlie/qtfm/issues/135
Now the selection is more natural, only icon + filename area is in range to select. But the visual feedback still selects the whole line (instead of just icon + filename).