### PR TITLE
Protection against accidental deletion

### DIFF
--- a/fm/src/mainwindow.cpp
+++ b/fm/src/mainwindow.cpp
@@ -1097,6 +1097,7 @@ void MainWindow::pasteLauncher(const QList<QUrl> &files,
         for (int i=0; i<cutList.size(); i++) {
             QFileInfo info(cutList.at(i));
             if (!info.isDir() && !info.isFile()) { continue; }
+            if (cutList.at(i) == (newPath + "/" + info.fileName())) { continue; }
             if (info.isDir()) { _dirs << info.absoluteFilePath(); }
             else if (info.isFile()) { _files << info.absoluteFilePath(); }
         }


### PR DESCRIPTION
If cut a file or a directory and accidentally paste in the original location then it will deleted 

This PR fixes it