### PR TITLE
include QDir::System on the list of files to show broken symlinks

### DIFF
--- a/libfm/fileutils.cpp
+++ b/libfm/fileutils.cpp
@@ -61,7 +61,7 @@ void FileUtils::recurseFolder(const QString &path, const QString &parent,
   // Get all files in this path
   QDir dir(path);
   QStringList files = dir.entryList(QDir::AllEntries | QDir::Files
-                                    | QDir::NoDotAndDotDot | QDir::Hidden);
+                                    | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
 
   // Go through all files in current directory
   for (int i = 0; i < files.count(); i++) {

--- a/libfm/mymodel.cpp
+++ b/libfm/mymodel.cpp
@@ -423,7 +423,7 @@ bool myModel::hasChildren(const QModelIndex &parent) const
     if (item && item->fileInfo().isDir()) {
         if (QDir(item->fileInfo()
                  .absoluteFilePath())
-                .entryInfoList(QDir::NoDotAndDotDot|QDir::AllEntries)
+                .entryInfoList(QDir::NoDotAndDotDot|QDir::AllEntries|QDir::System)
                 .count() > 0)
         {
             return true;


### PR DESCRIPTION
For part of https://github.com/rodlie/qtfm/issues/146. In the QDir doc we have for QDir::AllEntries: "List directories, files, drives and symlinks (this does not list broken symlinks unless you specify System).". Then the inclusion of QDir::System.