### PR TITLE
- respect DOCDIR path

### DIFF
--- a/libfm/libfm.pro
+++ b/libfm/libfm.pro
@@ -79,7 +79,7 @@ unix:!macx {
     CONFIG(with_includes): CONFIG += create_prl no_install_prl create_pc
 
     target.path = $${LIBDIR}
-    docs.path = $${DOCDIR}/$${QTFM_TARGET}-$${VERSION}
+    docs.path = $${DOCDIR}
     docs.files += \
                 $${top_srcdir}/LICENSE \
                 $${top_srcdir}/README.md \


### PR DESCRIPTION
Adding additional subdirectories beyond DOCDIR is troublesome for packaging. Please consider this patch for respecting DOCDIR path that is set.