### PR TITLE
display directory name on startup

### DIFF
--- a/fm/src/mainwindow.cpp
+++ b/fm/src/mainwindow.cpp
@@ -523,6 +523,13 @@ void MainWindow::loadSettings(bool wState, bool hState, bool tabState, bool thum
   // path in window title
   showPathInWindowTitle = settings->value("windowTitlePath", true).toBool();
   if (!showPathInWindowTitle) { setWindowTitle(APP_NAME); }
+  else {
+    QFileInfo name = modelList->fileInfo(modelList->index(startPath));
+    if (name.exists() && !name.isFile()) {
+        if (name.fileName().isEmpty()) { setWindowTitle(name.absolutePath()); }
+        else { setWindowTitle(curIndex.fileName()); }
+    }
+  }
 
   // 'copy of' filename
   copyXof = settings->value("copyXof", COPY_X_OF).toString();


### PR DESCRIPTION
On QtFM startup, window title is set to 'QtFM' regardless of settings. This patch fixes this.