### PR TITLE
Omit empty strings from desktop file categories and mimetypes

### DIFF
--- a/libfm/desktopfile.cpp
+++ b/libfm/desktopfile.cpp
@@ -26,13 +26,8 @@ DesktopFile::DesktopFile(const QString &fileName) {
   type = desktop.value("Type", "Application").toString();
   no_display = desktop.value("NoDisplay", false).toBool();
   terminal = desktop.value("Terminal", false).toBool();
-  categories = desktop.value("Categories").toString().remove(" ").split(";");
-  mimeType = desktop.value("MimeType").toString().remove(" ").split(";");
-
-  // Fix categories
-  if (categories.first().compare("") == 0) {
-    categories.removeFirst();
-  }
+  categories = desktop.value("Categories").toString().remove(" ").split(";", Qt::SkipEmptyParts);
+  mimeType = desktop.value("MimeType").toString().remove(" ").split(";", Qt::SkipEmptyParts);
 }
 //---------------------------------------------------------------------------
 


### PR DESCRIPTION
Reading "mimetype" and "categories" entries from a .desktop file that end in a trailing ';' causes an empty string to be added to the mimetype/categories qstringlist. For mimetypes, this causes an invalid mime file to be written as the empty string is used as the lefthand side of the default application entry...

[Default Applications]
=anydesk.desktop;&lt;snip further desktopfiles&gt;
application/clarisworks=libreoffice-calc.desktop;libreoffice-draw.desktop;libreoffice-writer.desktop
...
