### PR TITLE
iconview: Fix QPainterPath path has incomplete type

### DIFF
--- a/libfm/iconlist.h
+++ b/libfm/iconlist.h
@@ -9,6 +9,7 @@
 #include <QStyledItemDelegate>
 #include <QModelIndex>
 #include <QPainter>
+#include <QPainterPath>
 
 class IconListDelegate : public QItemDelegate
 {

--- a/libfm/iconview.h
+++ b/libfm/iconview.h
@@ -11,6 +11,7 @@
 #include <QKeyEvent>
 #include <QModelIndex>
 #include <QPainter>
+#include <QPainterPath>
 
 class IconViewDelegate : public QStyledItemDelegate
 {


### PR DESCRIPTION
Without this changes compiling with QT 5.15 will fail with `QPainterPath path has incomplete type`.