### PR TITLE
Fix thumbnail hash to that thumbnails made by 3rd party thumbnailers are shown

### DIFF
--- a/libfm/thumbnails.cpp
+++ b/libfm/thumbnails.cpp
@@ -87,7 +87,7 @@ bool Thumbnail::isValid()
 const QString Thumbnail::getFileHash()
 {
     if (!QFile::exists(_filename)) { return QString(); }
-    return QString(QCryptographicHash::hash(QUrl::fromUserInput(_filename).toString().toUtf8(), _hash).toHex());
+    return QString(QCryptographicHash::hash(QUrl::fromLocalFile(_filename).toEncoded(), _hash).toHex());
 }
 
 void Thumbnail::checkIcon()


### PR DESCRIPTION
Follow logic used in https://github.com/KDE/kio-extras/blob/master/thumbnail/thumbnail.cpp for constucting the hash