### PR TITLE
Port to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,10 @@ if(NOT ENABLE_UDISKS AND ENABLE_DBUS)
 endif()
 
 # qt
-find_package(QT NAMES Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets Concurrent REQUIRED)
 if(ENABLE_DBUS)
-    find_package(Qt${QT_VERSION_MAJOR} 5.15 COMPONENTS DBus REQUIRED)
+    find_package(Qt6 COMPONENTS DBus REQUIRED)
 endif()
-find_package(Qt${QT_VERSION_MAJOR} 5.15 COMPONENTS Gui Widgets Concurrent REQUIRED)
 
 # inotify
 if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
@@ -137,10 +136,9 @@ target_include_directories(QtFM PRIVATE libfm libfm/qtcopydialog ${NOTIFY_INCLUD
 
 target_link_libraries(
     QtFM
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Gui
-    Qt${QT_VERSION_MAJOR}::Widgets
-    Qt${QT_VERSION_MAJOR}::Concurrent
+    Qt::Core
+    Qt::Widgets
+    Qt::Concurrent
 )
 if(ENABLE_DBUS)
     target_link_libraries(QtFM Qt${QT_VERSION_MAJOR}::DBus QtFMBus)
@@ -166,10 +164,9 @@ add_executable(
 )
 target_link_libraries(
     ${PROJECT_NAME}
-    Qt${QT_VERSION_MAJOR}::Core
-    Qt${QT_VERSION_MAJOR}::Gui
-    Qt${QT_VERSION_MAJOR}::Widgets
-    Qt${QT_VERSION_MAJOR}::Concurrent
+    Qt::Core
+    Qt::Widgets
+    Qt::Concurrent
     QtFM
 )
 target_include_directories(${PROJECT_NAME} PRIVATE fm/src libfm libfm/qtcopydialog)
@@ -189,10 +186,9 @@ if(ENABLE_DBUS AND ENABLE_TRAY)
     target_include_directories(${PROJECT_NAME}-tray PRIVATE tray libfm)
     target_link_libraries(
         ${PROJECT_NAME}-tray
-        Qt${QT_VERSION_MAJOR}::Core
-        Qt${QT_VERSION_MAJOR}::Gui
-        Qt${QT_VERSION_MAJOR}::Widgets
-        Qt${QT_VERSION_MAJOR}::DBus
+        Qt::Core
+        Qt::Widgets
+        Qt::DBus
         QtFM
     )
 endif()

--- a/fm/src/actiondefs.cpp
+++ b/fm/src/actiondefs.cpp
@@ -436,7 +436,7 @@ void MainWindow::readShortcuts() {
         i.next();
         QStringList action;
         action << i.key() << i.value();
-        settings->setValue(QString(count), action);
+        settings->setValue(QString::number(count), action);
         ++count;
     }
     settings->endGroup();

--- a/fm/src/actiontriggers.cpp
+++ b/fm/src/actiontriggers.cpp
@@ -52,7 +52,8 @@ void MainWindow::executeFile(QModelIndex index, bool run) {
     QProcess::startDetached(filePath, QStringList());
 #endif
   } else {
-    mimeUtils->openInApp(filePath, ""/*term*/);
+    QFileInfo fi(filePath);
+    mimeUtils->openInApp(filePath, fi);
   }
 }
 //---------------------------------------------------------------------------
@@ -746,11 +747,11 @@ void MainWindow::toggleHidden() {
     if (curIndex.isHidden()) {
       listSelectionModel->clear();
     }
-    modelView->setFilterRegExp("no");
-    modelTree->setFilterRegExp("no");
+    modelView->setFilterRegularExpression("no");
+    modelTree->setFilterRegularExpression("no");
   } else {
-    modelView->setFilterRegExp("");
-    modelTree->setFilterRegExp("");
+    modelView->setFilterRegularExpression("");
+    modelTree->setFilterRegularExpression("");
   }
 
   modelView->invalidate();

--- a/fm/src/mainwindow.cpp
+++ b/fm/src/mainwindow.cpp
@@ -790,7 +790,6 @@ void MainWindow::listSelectionChanged(const QItemSelection selected, const QItem
 
         statusName->setText(name + "   ");
         statusSize->setText(QString("%1   ").arg(total));
-        
         QLocale locale;
         statusDate->setText(locale.toString(file.lastModified(), QLocale::ShortFormat));
     }

--- a/fm/src/tabbar.cpp
+++ b/fm/src/tabbar.cpp
@@ -63,7 +63,7 @@ void tabBar::dragEnterEvent(QDragEnterEvent *event)
 //---------------------------------------------------------------------------
 void tabBar::dragMoveEvent(QDragMoveEvent *event)
 {
-    this->setCurrentIndex(tabAt(event->pos()));
+    this->setCurrentIndex(tabAt(event->position().toPoint()));
     event->acceptProposedAction();
 }
 
@@ -73,7 +73,7 @@ void tabBar::dropEvent(QDropEvent *event)
     QList<QUrl> paths = event->mimeData()->urls();
     QFileInfo file = QFileInfo(paths.at(0).path());
 
-    if(tabAt(event->pos()) == -1 && file.isDir())           //new tab
+    if(tabAt(event->position().toPoint()) == -1 && file.isDir())           //new tab
         addNewTab(file.filePath(),0);
     else
     {

--- a/libfm/common.cpp
+++ b/libfm/common.cpp
@@ -166,8 +166,9 @@ QString Common::findIconInDir(QString appPath,
         QString iconName = QFileInfo(found).completeBaseName();
         if (iconName == icon) {
             for (int i=0;i<iconSizes.size();++i) {
-                QString hasFile = found.replace(QRegularExpression("/\\d+x\\d+/"),
-                                                QString("/%1x%1/").arg(iconSizes.at(i)));
+                static QRegularExpression re("/\\d+x\\d+/"); // match e.g. "/16x16/"
+                QString hasFile = found;
+                hasFile.replace(re, QString("/%1x%1/").arg(iconSizes.at(i)));                
                 if (QFile::exists(hasFile)) { return hasFile; }
             }
             return found;
@@ -183,8 +184,8 @@ QString Common::findIconInDir(QString appPath,
             QString iconName = QFileInfo(found).completeBaseName();
             if (iconName == icon) {
                 for (int i=0;i<iconSizes.size();++i) {
-                    QString hasFile = found.replace(QRegularExpression("/\\d+x\\d+/"),
-                                                    QString("/%1x%1/").arg(iconSizes.at(i)));
+                    static QRegularExpression re("/\\d+x\\d+/"); // match e.g. "/16x16/"
+                    QString hasFile = found;
                     if (QFile::exists(hasFile)) { return hasFile; }
                 }
                 return found;

--- a/libfm/common.cpp
+++ b/libfm/common.cpp
@@ -166,9 +166,8 @@ QString Common::findIconInDir(QString appPath,
         QString iconName = QFileInfo(found).completeBaseName();
         if (iconName == icon) {
             for (int i=0;i<iconSizes.size();++i) {
-                static QRegularExpression re("/\\d+x\\d+/"); // match e.g. "/16x16/"
-                QString hasFile = found;
-                hasFile.replace(re, QString("/%1x%1/").arg(iconSizes.at(i)));                
+                static QRegularExpression re("/\\d+x\\d+/");
+                QString hasFile = found.replace(re, QString("/%1x%1/").arg(iconSizes.at(i)));                
                 if (QFile::exists(hasFile)) { return hasFile; }
             }
             return found;
@@ -184,8 +183,8 @@ QString Common::findIconInDir(QString appPath,
             QString iconName = QFileInfo(found).completeBaseName();
             if (iconName == icon) {
                 for (int i=0;i<iconSizes.size();++i) {
-                    static QRegularExpression re("/\\d+x\\d+/"); // match e.g. "/16x16/"
-                    QString hasFile = found;
+                    static QRegularExpression re("/\\d+x\\d+/");
+                    QString hasFile = found.replace(re, QString("/%1x%1/").arg(iconSizes.at(i)));
                     if (QFile::exists(hasFile)) { return hasFile; }
                 }
                 return found;

--- a/libfm/dfmqtreeview.cpp
+++ b/libfm/dfmqtreeview.cpp
@@ -274,12 +274,14 @@ void DfmQTreeView::updateElasticBandSelection()
     }
 
     // Get the index of the item in this row in the name column.
-    // TODO - would this still work if the columns could be re-ordered?
-    QModelIndex startIndex = QTreeView::indexAt(boundingRect.topLeft());
-    if (startIndex.parent().isValid()) {
-        startIndex = startIndex.parent().child(startIndex.row(), COLUMN_NAME);
-    } else {
-        startIndex = model()->index(startIndex.row(), COLUMN_NAME);
+    QModelIndex startIndex = QTreeView::indexAt(boundingRect.topLeft());    
+    int nameColumn = model()->headerData(COLUMN_NAME, Qt::Horizontal, Qt::DisplayRole).toInt();
+    if (nameColumn != -1) {
+        if (startIndex.parent().isValid()) {
+            startIndex = model()->index(startIndex.row(), nameColumn, startIndex.parent());
+        } else {
+            startIndex = model()->index(startIndex.row(), nameColumn);
+        }
     }
     if (!startIndex.isValid()) {
         selectionModel()->select(m_band.originalSelection, QItemSelectionModel::ClearAndSelect);
@@ -437,7 +439,10 @@ QRect DfmQTreeView::nameColumnRect(const QModelIndex& index) const
 
     if (index.isValid()) {
         QString filename = index.data(Qt::DisplayRole).toString();
-        const int itemContentWidth = DfmQStyledItemDelegate::nameColumnWidth(filename, QTreeView::viewOptions());
+        QStyleOptionViewItem option;
+        option.initFrom(this);
+        option.rect = guessedItemContentRect;
+        const int itemContentWidth = DfmQStyledItemDelegate::nameColumnWidth(filename, option);
         guessedItemContentRect.setWidth(itemContentWidth);
     }
 

--- a/libfm/icondlg.cpp
+++ b/libfm/icondlg.cpp
@@ -56,7 +56,7 @@ icondlg::icondlg()
         }
     }
 
-    thread.setFuture(QtConcurrent::run(this,&icondlg::scanTheme));
+    thread.setFuture(QtConcurrent::run(&icondlg::scanTheme, this));
     connect(&thread,SIGNAL(finished()),this,SLOT(loadIcons()));
 }
 

--- a/libfm/mymodel.cpp
+++ b/libfm/mymodel.cpp
@@ -1134,7 +1134,7 @@ QVariant myModel::data(const QModelIndex & index, int role) const {
   // Alignment of filename
   else if (role == Qt::TextAlignmentRole) {
     if (index.column() == 1) {
-      return Qt::AlignRight + Qt::AlignVCenter;
+      return QVariant::fromValue(Qt::AlignRight | Qt::AlignVCenter);
     }
   }
   // Display information about file

--- a/libfm/propertiesdlg.cpp
+++ b/libfm/propertiesdlg.cpp
@@ -252,7 +252,7 @@ PropertiesDialog::PropertiesDialog(QStringList paths, myModel *modelList) {
   layout->addWidget(buttons);
   setLayout(layout);
 
-  layout->setMargin(6);
+  layout->setContentsMargins(6, 6, 6, 6);
   layout->setSpacing(4);
 
   connect(this, SIGNAL(updateSignal()), this, SLOT(update()));
@@ -262,7 +262,9 @@ PropertiesDialog::PropertiesDialog(QStringList paths, myModel *modelList) {
   setMinimumSize(size());
 
   this->setAttribute(Qt::WA_DeleteOnClose,1);
-  thread = QtConcurrent::run(this, &PropertiesDialog::folderProperties, paths);
+  thread = QtConcurrent::run([this, paths]() {
+      this->folderProperties(paths);
+  });
 }
 //---------------------------------------------------------------------------
 

--- a/libfm/qtcopydialog/qtcopydialog.h
+++ b/libfm/qtcopydialog/qtcopydialog.h
@@ -59,8 +59,8 @@ class QT_QTCOPYDIALOG_EXPORT QtCopyDialog : public QDialog
     Q_PROPERTY(bool autoClose READ autoClose WRITE setAutoClose)
 public:
 
-    QtCopyDialog(QWidget *parent = 0, bool delOnClose = true, Qt::WindowFlags f = 0);
-    QtCopyDialog(QtFileCopier *copier, QWidget *parent = 0, bool delOnClose = true, Qt::WindowFlags f = 0);
+    QtCopyDialog(QWidget *parent = 0, bool delOnClose = true, Qt::WindowFlags f = {});
+    QtCopyDialog(QtFileCopier *copier, QWidget *parent = 0, bool delOnClose = true, Qt::WindowFlags f = {});
     ~QtCopyDialog();
 
     void setFileCopier(QtFileCopier *copier);

--- a/libfm/qtcopydialog/qtfilecopier.cpp
+++ b/libfm/qtcopydialog/qtfilecopier.cpp
@@ -1141,7 +1141,9 @@ QMap<int, CopyRequest> QtFileCopierPrivate::copyDirectoryContents(const QString 
             QFileInfo newfid(destDir.filePath(dirName));
             QMap<int, CopyRequest> childDir = copyDirectoryContents(newfis.filePath(),
                             newfid.filePath(), flags, move);
-            resultList.unite(childDir);
+            for (const auto &key : childDir.keys()) {
+                resultList.insert(key, childDir.value(key));
+            }
             resultList[curId].childrenQueue.enqueue(childDir.constBegin().key());
         }
     }

--- a/libfm/qtcopydialog/qtfilecopier.h
+++ b/libfm/qtcopydialog/qtfilecopier.h
@@ -111,18 +111,18 @@ public:
     Q_DECLARE_FLAGS(CopyFlags, CopyFlag)
 
     int copy(const QString &sourceFile, const QString &destinationPath,
-                CopyFlags flags = 0);
+                CopyFlags flags = {});
     QList<int> copyFiles(const QStringList &sourceFiles, const QString &destinationDir,
-                CopyFlags flags = 0);
+                CopyFlags flags = {});
     QList<int> copyDirectory(const QString &sourceDir, const QString &destinationDir,
-                CopyFlags flags = 0);
+                CopyFlags flags = {});
 
     int move(const QString &sourceFile, const QString &destinationPath,
-                CopyFlags flags = 0);
+                CopyFlags flags = {});
     QList<int> moveFiles(const QStringList &sourceFiles, const QString &destinationDir,
-                CopyFlags flags = 0);
+                CopyFlags flags = {});
     QList<int> moveDirectory(const QString &sourceDir, const QString &destinationDir,
-                CopyFlags flags = 0);
+                CopyFlags flags = {});
 
     QList<int> pendingRequests() const;
     QString sourceFilePath(int id) const;

--- a/libfm/sortmodel.cpp
+++ b/libfm/sortmodel.cpp
@@ -9,7 +9,7 @@ bool mainTreeFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex
     myModel* fileModel = qobject_cast<myModel*>(sourceModel());
     if (fileModel == nullptr) { return false; }
     if (fileModel->isDir(index0)) {
-        if (this->filterRegExp().isEmpty() || fileModel->fileInfo(index0).isHidden() == 0) { return true; }
+        if (this->filterRegularExpression().pattern().isEmpty() || !fileModel->fileInfo(index0).isHidden()) { return true; }
     }
 
     return false;
@@ -18,7 +18,7 @@ bool mainTreeFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex
 //---------------------------------------------------------------------------------
 bool viewsSortProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
 {
-    if (this->filterRegExp().isEmpty()) { return true; }
+    if (this->filterRegularExpression().pattern().isEmpty()) { return true; }    
 
     QModelIndex index0 = sourceModel()->index(sourceRow, 0, sourceParent);
     myModel* fileModel = qobject_cast<myModel*>(sourceModel());


### PR DESCRIPTION
I am only dealing with CMake, and PRO files are legacy as Qt5. Code runs, but I cannot open external files (clicking a TXT file does nothing for example). The tray , does nothing. Menus behave properly now as Qt5 has very bad Wayland support. I am testing against Qt from debian, 6.8.3 and 6.9.0 from upstream. Not compiling with MAGIC support.

On the left, Qt5 build before the changes. On the right, Qt from debian:
![qtfm-qt6](https://github.com/user-attachments/assets/361a9fcc-0c59-4ecb-8980-e069d9ffd8aa)

IMHO the code can be made to compiler on Qt5 (the normal CMake magic - just modify at the top, `Qt::Widgets` works on Qt5 and Qt6). I don't see any reason to spend time on this.
